### PR TITLE
カスタムヘッダーを作成可能に

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -51,7 +51,8 @@ class MyHomePage extends StatefulWidget {
 class _MyHomePageState extends State<MyHomePage> {
   DateTime _currentDate = DateTime(2019, 2, 3);
   DateTime _currentDate2 = DateTime(2019, 2, 3);
-  String _currentMonth = '';
+  String _currentMonth = DateFormat.yMMM().format(DateTime(2019, 2, 3));
+  DateTime _targetDateTime = DateTime(2019, 2, 3);
 //  List<DateTime> _markedDate = [DateTime(2018, 9, 20), DateTime(2018, 10, 11)];
   static Widget _eventIcon = new Container(
     decoration: new BoxDecoration(
@@ -209,6 +210,7 @@ class _MyHomePageState extends State<MyHomePage> {
       markedDatesMap: _markedDateMap,
       height: 420.0,
       selectedDateTime: _currentDate2,
+      targetDateTime: _targetDateTime,
       customGridViewPhysics: NeverScrollableScrollPhysics(),
       markedDateCustomShapeBorder: CircleBorder(
         side: BorderSide(color: Colors.yellow)
@@ -241,7 +243,10 @@ class _MyHomePageState extends State<MyHomePage> {
         fontSize: 16,
       ),
       onCalendarChanged: (DateTime date) {
-        this.setState(() => _currentMonth = DateFormat.yMMM().format(date));
+        this.setState(() {
+          _targetDateTime = date;
+          _currentMonth = DateFormat.yMMM().format(_targetDateTime);
+        });
       },
       onDayLongPressed: (DateTime date) {
         print('long pressed date $date');
@@ -284,10 +289,8 @@ class _MyHomePageState extends State<MyHomePage> {
                       child: Text('PREV'),
                       onPressed: () {
                         setState(() {
-                          _currentDate2 =
-                              _currentDate2.subtract(Duration(days: 30));
-                          _currentMonth =
-                              DateFormat.yMMM().format(_currentDate2);
+                          _targetDateTime = DateTime(_targetDateTime.year, _targetDateTime.month -1);
+                          _currentMonth = DateFormat.yMMM().format(_targetDateTime);
                         });
                       },
                     ),
@@ -295,9 +298,8 @@ class _MyHomePageState extends State<MyHomePage> {
                       child: Text('NEXT'),
                       onPressed: () {
                         setState(() {
-                          _currentDate2 = _currentDate2.add(Duration(days: 30));
-                          _currentMonth =
-                              DateFormat.yMMM().format(_currentDate2);
+                          _targetDateTime = DateTime(_targetDateTime.year, _targetDateTime.month +1);
+                          _currentMonth = DateFormat.yMMM().format(_targetDateTime);
                         });
                       },
                     )

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -258,7 +258,7 @@ class _CalendarState<T extends EventInterface> extends State<CalendarCarousel<T>
         _targetDate = _firstDayOfWeek(_selectedDate);
       }
       for (int _cnt = 0;
-      0 > widget.minSelectedDate.add(Duration(days: 7 * _cnt)).difference(_targetDate).inDays;
+      0 > minDate.add(Duration(days: 7 * _cnt)).difference(_targetDate).inDays;
       _cnt++) {
         this._pageNum = _cnt + 1;
       }
@@ -269,8 +269,8 @@ class _CalendarState<T extends EventInterface> extends State<CalendarCarousel<T>
         _targetDate = _selectedDate;
       }
       for (int _cnt = 0;
-      0 > DateTime(widget.minSelectedDate.year,
-        widget.minSelectedDate.month + _cnt,
+      0 > DateTime(minDate.year,
+        minDate.month + _cnt,
       ).difference(DateTime(_targetDate.year, _targetDate.month)).inDays;
       _cnt++) {
         this._pageNum = _cnt + 1;

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -251,23 +251,30 @@ class _CalendarState<T extends EventInterface> extends State<CalendarCarousel<T>
     if (widget.selectedDateTime != null)
       _selectedDate = widget.selectedDateTime;
 
-    if (widget.weekFormat) {
-      if (widget.targetDateTime != null) {
-        _targetDate = _firstDayOfWeek(widget.targetDateTime);
+    if (widget.targetDateTime != null) {
+      if (widget.targetDateTime
+          .difference(minDate)
+          .inDays < 0) {
+        _targetDate = minDate;
+      } else if (widget.targetDateTime
+          .difference(maxDate)
+          .inDays > 0) {
+        _targetDate = maxDate;
       } else {
-        _targetDate = _firstDayOfWeek(_selectedDate);
+        _targetDate = widget.targetDateTime;
       }
+    } else {
+      _targetDate = _selectedDate;
+    }
+
+    if (widget.weekFormat) {
+      _targetDate = _firstDayOfWeek(_targetDate);
       for (int _cnt = 0;
       0 > minDate.add(Duration(days: 7 * _cnt)).difference(_targetDate).inDays;
       _cnt++) {
         this._pageNum = _cnt + 1;
       }
     } else {
-      if (widget.targetDateTime != null) {
-        _targetDate = widget.targetDateTime;
-      } else {
-        _targetDate = _selectedDate;
-      }
       for (int _cnt = 0;
       0 > DateTime(minDate.year,
         minDate.month + _cnt,
@@ -300,9 +307,14 @@ class _CalendarState<T extends EventInterface> extends State<CalendarCarousel<T>
   void didUpdateWidget(CalendarCarousel<T> oldWidget) {
     if (widget.targetDateTime != null && widget.targetDateTime != _targetDate) {
       DateTime targetDate = widget.targetDateTime;
+      if (widget.targetDateTime.difference(minDate).inDays < 0) {
+        targetDate = minDate;
+      } else if (widget.targetDateTime.difference(maxDate).inDays > 0) {
+        targetDate = maxDate;
+      }
       int _page = this._pageNum;
       if (widget.weekFormat) {
-        targetDate = _firstDayOfWeek(widget.targetDateTime);
+        targetDate = _firstDayOfWeek(targetDate);
         for (int _cnt = 0;
         0 > widget.minSelectedDate.add(Duration(days: 7 * _cnt)).difference(targetDate).inDays;
         _cnt++) {

--- a/lib/flutter_calendar_carousel.dart
+++ b/lib/flutter_calendar_carousel.dart
@@ -66,6 +66,7 @@ class CalendarCarousel<T extends EventInterface> extends StatefulWidget {
   final Color todayBorderColor;
   final Color todayButtonColor;
   final DateTime selectedDateTime;
+  final DateTime targetDateTime;
   final TextStyle selectedDayTextStyle;
   final Color selectedDayButtonColor;
   final Color selectedDayBorderColor;
@@ -147,6 +148,7 @@ class CalendarCarousel<T extends EventInterface> extends StatefulWidget {
     this.todayBorderColor = Colors.red,
     this.todayButtonColor = Colors.red,
     this.selectedDateTime,
+    this.targetDateTime,
     this.selectedDayTextStyle,
     this.selectedDayBorderColor = Colors.green,
     this.selectedDayButtonColor = Colors.green,
@@ -249,18 +251,26 @@ class _CalendarState<T extends EventInterface> extends State<CalendarCarousel<T>
     if (widget.selectedDateTime != null)
       _selectedDate = widget.selectedDateTime;
 
-    _targetDate = _selectedDate;
-
     if (widget.weekFormat) {
+      if (widget.targetDateTime != null) {
+        _targetDate = _firstDayOfWeek(widget.targetDateTime);
+      } else {
+        _targetDate = _firstDayOfWeek(_selectedDate);
+      }
       for (int _cnt = 0;
-      0 > minDate.add(Duration(days: 7 * _cnt)).difference(_targetDate).inDays;
+      0 > widget.minSelectedDate.add(Duration(days: 7 * _cnt)).difference(_targetDate).inDays;
       _cnt++) {
         this._pageNum = _cnt + 1;
       }
     } else {
+      if (widget.targetDateTime != null) {
+        _targetDate = widget.targetDateTime;
+      } else {
+        _targetDate = _selectedDate;
+      }
       for (int _cnt = 0;
-      0 > DateTime(minDate.year,
-        minDate.month + _cnt,
+      0 > DateTime(widget.minSelectedDate.year,
+        widget.minSelectedDate.month + _cnt,
       ).difference(DateTime(_targetDate.year, _targetDate.month)).inDays;
       _cnt++) {
         this._pageNum = _cnt + 1;
@@ -284,6 +294,34 @@ class _CalendarState<T extends EventInterface> extends State<CalendarCarousel<T>
       firstDayOfWeek = widget.firstDayOfWeek;
 
     _setDate();
+  }
+
+  @override
+  void didUpdateWidget(CalendarCarousel<T> oldWidget) {
+    if (widget.targetDateTime != null && widget.targetDateTime != _targetDate) {
+      DateTime targetDate = widget.targetDateTime;
+      int _page = this._pageNum;
+      if (widget.weekFormat) {
+        targetDate = _firstDayOfWeek(widget.targetDateTime);
+        for (int _cnt = 0;
+        0 > widget.minSelectedDate.add(Duration(days: 7 * _cnt)).difference(targetDate).inDays;
+        _cnt++) {
+          _page = _cnt + 1;
+        }
+      } else {
+        for (int _cnt = 0;
+        0 > DateTime(widget.minSelectedDate.year,
+          widget.minSelectedDate.month + _cnt,
+        ).difference(DateTime(targetDate.year, targetDate.month)).inDays;
+        _cnt++) {
+          _page = _cnt + 1;
+        }
+      }
+
+      _setDate(_page);
+    }
+
+    super.didUpdateWidget(oldWidget);
   }
 
   @override


### PR DESCRIPTION
表示月を引数として受け入れることによって、
カレンダー外部で表示月を制御可能となる。
この結果従来のexsampleのカスタムヘッダーを利用することができるようになった。